### PR TITLE
UI改善: カードのテキストオーバーフロー修正、ホームへの戻り機能追加、フィルタリング機能強化

### DIFF
--- a/kanpo-viewer/src/App.jsx
+++ b/kanpo-viewer/src/App.jsx
@@ -165,15 +165,18 @@ function App() {
 
       <footer className="footer footer-center p-10 bg-base-200 text-base-content rounded">
         <div>
-          <p>
-            <strong>官報RSS Viewer</strong> -
+          <p className="flex items-center justify-center gap-2">
+            <strong>官報RSS Viewer</strong>
             <a
               href="https://github.com/testkun08080/kanpo-rss"
-              className="link link-primary"
+              className="btn btn-ghost btn-circle btn-sm"
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="GitHub"
             >
-              GitHub
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+              </svg>
             </a>
           </p>
           <p>本RSSは非公式のものであり、正確性を保証するものではありません。</p>

--- a/kanpo-viewer/src/components/Header.jsx
+++ b/kanpo-viewer/src/components/Header.jsx
@@ -3,7 +3,7 @@ function Header() {
     <header className="navbar bg-primary text-primary-content shadow-lg">
       <div className="container mx-auto">
         <div className="flex-1">
-          <a href="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
+          <a href="/kanpo-rss/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
             <img
               src="https://raw.githubusercontent.com/testkun08080/kanpo-rss/refs/heads/main/images/logo.png"
               alt="官報ロゴ"


### PR DESCRIPTION
以下の改善を実装しました：

## 修正内容

### 1. アイテムのカードの文字列がカードからはみ出る問題を修正
- タイトルと説明文に `break-words` と `overflow-hidden` クラスを追加して、テキストが適切に折り返されるようにしました

### 2. ヘッダーの左上アイコンとテキストを押した時にホームへ戻る機能を追加
- ヘッダーのロゴとテキスト部分を `<a href="/kanpo-rss/">` タグで囲み、クリック可能にしました
- リンク先を `/kanpo-rss/` に設定して正しいホームページに戻るようにしました

### 3. タグの種類でフィルタリングできる機能を追加
- 各アイテムのタイプ（本紙、号外、政府調達など）に基づいてフィルタリングできるチェックボックスを追加しました
- 複数のタグを同時に選択できるようにしました
- 利用可能なタグは動的に生成されます

### 4. 月日の設定でフィルタリングできる機能を追加
- 開始日と終了日を指定して期間でフィルタリングできる日付選択フィールドを追加しました
- 同じ日付を開始と終了に設定した場合でも、その日のアイテムが表示されるように修正しました

### 5. フッターのGitHubリンクをアイコンに変更
- テキストリンクからGitHubアイコンボタンに変更しました

## その他の改善
- 開発環境の改善として、Vite設定にCORSとホスト設定を追加しました

@testkun08080 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4c1352147e0640a2ad558e40858fb374)